### PR TITLE
Fix MakeCL

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -17,4 +17,4 @@ export NODE_VERSION_LTS=22.16.0
 export SPACEMAN_DMM_VERSION=suite-1.10
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.12.12
+export PYTHON_VERSION=3.12.10


### PR DESCRIPTION
Seems like github yote support for 3.9, so I'm just bumping the python setup version to 3.12.12 (only two minor versions above our dependencies one).

I'd bump the dependencies.sh python to the same version if it weren't for the fact there's no windows build.

Let's hope this doesn't break anything and leave me in python hell for an afternoon.